### PR TITLE
chore: ignore /docs in the htmltest configuration

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -8,3 +8,4 @@ CacheExpires: "12h" # Default is 2 weeks.
 ExternalTimeout: 60 # (seconds) default is 15.
 IgnoreURLs:
   - https://crc.dev/docs
+  - /docs


### PR DESCRIPTION
Ignore /docs in the htmltest configuration files to workaround absolute links in the 404 page.

It fixes following error:

```
make docs_check_links 
podman run -v /home/ffloreth/src/gl/ffloreth/crc-docs:/test:Z --rm docker.io/wjdp/htmltest:latest -c .htmltest.yml
htmltest started at 08:24:16 on ./public
========================================================================
404.html
  target does not exist --- 404.html --> /docs/_/css/site.css
  target does not exist --- 404.html --> /docs/getting_started/getting_started/introducing/
  target does not exist --- 404.html --> /docs/getting_started/getting_started/introducing/
  target does not exist --- 404.html --> /docs/_/js/site.js
  target does not exist --- 404.html --> /docs/_/js/vendor/highlight.js
  target does not exist --- 404.html --> /docs/_/js/vendor/lunr.js
  target does not exist --- 404.html --> /docs/_/js/search-ui.js
  target does not exist --- 404.html --> /docs/search-index.js
========================================================================
✘✘✘ failed in 10.09195085s
8 errors in 10 documents

```