### PR TITLE
chore: use the edit_url

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Build docs
-        run: CONTAINER_RUNTIME=docker make build_docs
+        run: CONTAINER_RUNTIME=docker CI=true make build_docs
       #- name: Check links in docs
       #  run: CONTAINER_RUNTIME=docker make docs_check_links
       - name: Deploy


### PR DESCRIPTION
The "Edit this page" link should point to the GitHub repository.

See: https://docs.antora.org/antora/latest/playbook/content-edit-url/

If the page originates from the local filesystem (i.e., a worktree), the default UI uses the local file:// URI for the Edit this Page link. You can force the default UI to always use the edit URL by setting the CI environment variable (e.g., CI=true) when building the site. (This environment variable is already set in most CI environments). The assumption is that if the CI environment variable is set, the site is being published to a remote server where a file:// URI would not be accessible. Rather than setting this environment variable, you can customize the UI template to change the logic.

