### PR TITLE
chore: added redirections for old URLs

### DIFF
--- a/modules/ROOT/pages/administrative-tasks.adoc
+++ b/modules/ROOT/pages/administrative-tasks.adoc
@@ -1,4 +1,5 @@
 :description: Administrative tasks
+:page-aliases: getting_started:getting_started:administrative-tasks.adoc
 = Administrative tasks
 
 == Starting monitoring

--- a/modules/ROOT/pages/configuring.adoc
+++ b/modules/ROOT/pages/configuring.adoc
@@ -1,4 +1,5 @@
 :description: Configuring {prod}
+:page-aliases: getting_started:getting_started:configuring.adoc
 = Configuring {prod}
 
 [id='about-configuration']

--- a/modules/ROOT/pages/installing.adoc
+++ b/modules/ROOT/pages/installing.adoc
@@ -1,4 +1,5 @@
 :description: Installing {prod}
+:page-aliases: getting_started:getting_started:installing.adoc
 = Installing {prod}
 
 [id='minimum-system-requirements']

--- a/modules/ROOT/pages/introducing.adoc
+++ b/modules/ROOT/pages/introducing.adoc
@@ -1,4 +1,5 @@
 :description: Introducing  {prod}
+:page-aliases: getting_started:getting_started:introducing.adoc
 = Introducing {rh-prod}
 
 [id='about']

--- a/modules/ROOT/pages/networking.adoc
+++ b/modules/ROOT/pages/networking.adoc
@@ -1,4 +1,5 @@
 :description: Networking
+:page-aliases: getting_started:getting_started:networking.adoc
 = Networking
 
 == DNS configuration details

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -1,4 +1,5 @@
 :description: Troubleshooting {prod}
+:page-aliases: getting_started:getting_started:troubleshooting.adoc
 
 [id="troubleshooting"]
 = Troubleshooting {rh-prod}

--- a/modules/ROOT/pages/using.adoc
+++ b/modules/ROOT/pages/using.adoc
@@ -1,4 +1,5 @@
 :description: Using {prod}
+:page-aliases: getting_started:getting_started:using.adoc
 [id="using_{context}"]
 = Using {prod}
 


### PR DESCRIPTION
Added redirections for old URLS:

* /crc/getting_started/getting_started/installing
* /crc/getting_started/getting_started/introducing
* /crc/getting_started/getting_started/using
* /crc/getting_started/getting_started/networking
* /crc/getting_started/getting_started/configuring
* /crc/getting_started/getting_started/troubleshooting
* /crc/getting_started/getting_started/administrative-tasks 	