### PR TITLE
doc : Add steps to remove CRC pull secret from OS provided tools (#2572)

### DIFF
--- a/modules/ROOT/pages/using.adoc
+++ b/modules/ROOT/pages/using.adoc
@@ -95,6 +95,102 @@ $ crc setup # Initialize environment for cluster
 $ crc start # Start the cluster
 ----
 
+[id='about-pullsecrets']
+== About Pull Secrets
+When using the {openshift} or {ushift} preset, {prod} requires a pull secret:
+
+. To pull the virtual machine bundle.
+. To pull {ocp} container images from the Red Hat registry.
+
+When running [command]`{bin} start` the first time, when the pull secret has not been provisioned, {prod} prompts to provide a pull secret.
+
+=== Providing pull secret to {prod}
+
+.Prerequisites
+. Download pull secret from the Pull Secret section of the link:https://console.redhat.com/openshift/create/local[{prod} page on the {rh} Hybrid Cloud Console] to _<pull_secret_file>_ location.
+
+.Procedure
+* Enter pull secret value when {prod} prompts to provide pull secret.
+{prod} stores the pull secret in the Operating System's credential manager so that {prod} doesn't ask for pull secret again in case existing cluster is deleted and a new one is created.
++
+[subs="+attributes,+quotes"]
+----
+$ {bin} start
+...
+? Please enter the pull secret
+----
++
+[TIP]
+====
+Alternatively, specify pull secret file location by using the `--pull-secret-file` CLI argument.
+[subs="+attributes,+quotes"]
+----
+$ {bin} start --pull-secret-file=_<pull_secret_file>_
+----
+====
++
+[TIP]
+====
+Alternatively, specify pull secret file location by setting the `pull-secret-file` configuration.
+[subs="+attributes,+quotes"]
+----
+$ {bin} config set pull-secret-file _<pull_secret_file>_
+$ {bin} start
+----
+====
+
+Please note that this pull secret would only be removed from the Operating System's credential manager when user runs [command]`{bin} cleanup` command.
+
+It's also possible to remove pull secret from the Operating System's credential manager configuration manually. 
+
+[id='clearning-credential-manager-pullsecret']
+=== Clearing Pull Secret from Credential Manager
+Steps to clear entries from the Credential Manager on different operating systems.
+
+==== Windows
+
+. Open the Control Panel.
+. Go to `User Accounts` > `Credential Manager`.
+. Choose `Windows Credentials`.
+. Find the {prod} pull secret entry to delete.
+. Click on the entry to expand it.
+. Click `Remove` to delete the credential.
+
+==== Linux
+
+If using https://wiki.gnome.org/Projects/GnomeKeyring[GNOME Keyring]:
+
+. Open the `Activities` overview and type `Passwords`.
+. Click on `Passwords and Keys` to open https://wiki.gnome.org/Projects/GnomeKeyring[GNOME Keyring].
+. Click on `Login` entry under `Passwords`
+. Find the {prod} pull secret entry to delete.
+. Right-click the entry to delete.
+. Select `Delete` and confirm the deletion.
+
+If using https://github.com/KDE/kwallet[KDE Wallet]:
+
+[NOTE]
+====
+By default, https://github.com/KDE/kwallet[KDE Wallet] doesn't operate as a Secret Service Provider. This needs to be explicitly
+enable it by going to `System Settings` > `KDE Wallet` and enable Use KWallet for the Secret Service interface. Then {prod} can be used
+with https://github.com/KDE/kwallet[KDE Wallet]
+====
+
+. Open the `Application Launcher`  and type `KWalletManager`.
+. Under `Contents` tab, click on `Secret Service` and expand it.
+. Under expanded `Secret Service` entry, click on `Passwords` and expand it.
+. Find the {prod} pull secret entry.
+. Right-click the entry to delete.
+. Select `Delete` and confirm the deletion.
+
+==== MacOS
+
+. Open `Keychain Access` from the `Applications` > `Utilities` folder.
+. Select the keychain where the credential is stored (e.g., `login`, `iCloud`).
+. Find the {prod} pull secret entry to delete.
+. Right-click the entry and select `Delete`.
+. Confirm the deletion when prompted.
+
 [id='setting-up']
 == Setting up {prod}
 


### PR DESCRIPTION
## Description

Fix https://github.com/crc-org/crc/issues/2572

Add steps for Windows, Linux (GNOME), and MacOS to instruct users on removing the CRC pull secret from credential managers on the abovementioned Operating Systems.

I've tested these steps on:
- Windows 11
- GNOME Desktop Linux
- KDE Desktop Linux


For MacOS I got help from Anjan who verified steps there.