### PR TITLE
doc : add getting started guides for OKD, OpenShift and Microshift preset

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,5 +1,6 @@
-= Getting Started Guide
+= Documentation
 
+* xref:getting-started.adoc[]
 * xref:introducing.adoc[]
 * xref:installing.adoc[]
 * xref:using.adoc[]

--- a/modules/ROOT/pages/getting-started-scenarios/microshift.adoc
+++ b/modules/ROOT/pages/getting-started-scenarios/microshift.adoc
@@ -1,0 +1,50 @@
+We will be creating a single-node cluster for https://www.redhat.com/en/topics/edge-computing/microshift[{ushift}].
+
+Once you've downloaded and installed {prod} on your machine, you're ready to use {prod} by creating a cluster. https://www.redhat.com/en/topics/edge-computing/microshift[{ushift}]
+is not the default cluster type that would be created when no explicit configuration is provided.
+
+In order to instruct {prod} to create a https://www.redhat.com/en/topics/edge-computing/microshift[{ushift}] cluster, we need to update {prod} configuration:
+
+[subs="+quotes,attributes"]
+----
+$ {bin} config set preset microshift
+----
+
+**Set up environment for your cluster**
+
+Before starting cluster, you need to prepare your machine for creating a Virtual Machine. {ushift} cluster would be started
+inside that Virtual Machine. In order to do that use xref:using.adoc#setting-up[`{bin} setup`] command.
+
+Open a terminal with a user account with administrator access (but not logged in as root user) and run:
+[subs="+quotes,attributes"]
+----
+$ {bin} setup
+----
+
+**Start your cluster**
+
+Once you've set up environment for your {ushift} cluster, you can go ahead and start it.
+
+[subs="+quotes,attributes"]
+----
+$ {bin} start
+----
+
+**Deploy a sample application to your {ushift} cluster**
+
+Create a sample deployment and expose it on port 8080:
+
+[subs="+quotes,attributes"]
+----
+$ oc create deployment hello-crc --image=registry.access.redhat.com/ubi8/httpd-24
+$ oc expose deployment hello-crc --type=NodePort --port=8080
+$ oc expose svc/hello-crc
+----
+
+Wait for application pod to become ready and access application via route:
+
+[subs="+quotes,attributes"]
+----
+$ oc get routes
+$ curl http://hello-crc-default.apps.crc.testing
+----

--- a/modules/ROOT/pages/getting-started-scenarios/okd.adoc
+++ b/modules/ROOT/pages/getting-started-scenarios/okd.adoc
@@ -1,0 +1,85 @@
+We will be creating a single-node cluster for https://okd.io/docs/project/about[OpenShift Kubernetes Distribution].
+
+Once you've downloaded and installed {prod} on your machine, you're ready to use {prod} by creating a cluster. https://okd.io/docs/documentation/[{okd}]
+is not the default cluster type that would be created when no explicit configuration is provided.
+
+In order to instruct {prod} to create a https://okd.io/docs/documentation/[{okd}] cluster, we need to update {prod} configuration:
+
+[subs="+quotes,attributes"]
+----
+$ {bin} config set preset okd
+----
+
+**Set up environment for your cluster**
+
+Before starting cluster, you need to prepare your machine for creating a Virtual Machine. {okd} cluster would be started
+inside that Virtual Machine. In order to do that use xref:using.adoc#setting-up[`{bin} setup`] command.
+
+Open a terminal with a user account with administrator access (but not logged in as root user) and run:
+[subs="+quotes,attributes"]
+----
+$ {bin} setup
+----
+
+**Start your cluster**
+
+Once you've set up environment for your {okd} cluster, you can go ahead and start it.
+
+[subs="+quotes,attributes"]
+----
+$ {bin} start
+----
+
+**Log into your {OKD} cluster**
+
+Once you've created the cluster, and it's up and running, you need to log in into your {okd} cluster. In order to do that, use {okd} CLI ([command]`oc`).
+
+If you already have {openshift} CLI ([command]`oc`), you can start using it. If not, you can use Run the [command]`{bin} oc-env`
+command to print the command needed to add the cached [command]`oc` executable to your `$PATH`.
+
+[subs="+quotes,attributes"]
+----
+$ {bin} oc-env
+----
+
+Get the {openshift} CLI ([command]`oc`) login command using [command]`{bin} console` to login as regular user or admin.
+
+Copy login command from this {prod} command output and paste it into your terminal:
+[subs="+quotes,attributes"]
+----
+$ {bin} console --credentials
+----
+
+**Deploy a sample application to your {okd} cluster**
+
+We will be deploying a simple Java application using a tool called https://eclipse.dev/jkube/docs/openshift-maven-plugin/[Eclipse JKube OpenShift Maven Plugin].
+
+In order to follow these steps, you would need to have these installed:
+
+- https://adoptium.net/temurin/releases/[Java Development Kit]
+- https://maven.apache.org/[Apache Maven]
+
+Once you've installed these dependencies, you can deploy any java application to {okd} cluster.
+
+Clone Eclipse JKube repository and go to one of the quickstarts:
+
+[subs="+quotes,attributes"]
+----
+$ git clone https://github.com/eclipse-jkube/jkube.git
+$ cd jkube/quickstarts/maven/quarkus
+----
+
+Run JKube OpenShift Maven Plugin goal to build and deploy application to {okd} cluster:
+
+[subs="+quotes,attributes"]
+----
+$ mvn package oc:build oc:resource oc:apply
+----
+
+Wait till application pod comes in ready state and access the application via route:
+
+[subs="+quotes,attributes"]
+----
+$ oc get routes
+$ curl http://quarkus-default.apps-crc.testing
+----

--- a/modules/ROOT/pages/getting-started-scenarios/openshift.adoc
+++ b/modules/ROOT/pages/getting-started-scenarios/openshift.adoc
@@ -1,0 +1,81 @@
+We will be creating a single-node cluster for https://www.redhat.com/en/technologies/cloud-computing/openshift/container-platform[Red Hat OpenShift Container Platform].
+
+Once you've downloaded and installed {prod} on your machine, you're ready to use {prod} by creating a cluster. {openshift}
+is the default cluster type that would be created when no explicit configuration is provided.
+
+**Set up environment for your cluster**
+
+Before starting cluster, you need to prepare your machine for creating a Virtual Machine. {openshift} cluster would be started
+inside that Virtual Machine. In order to do that use xref:using.adoc#setting-up[`{bin} setup`] command.
+
+Open a terminal with a user account with administrator access (but not logged in as root user) and run:
+[subs="+quotes,attributes"]
+----
+$ {bin} setup
+----
+
+**Start your cluster**
+
+Once you've set up environment for your {openshift} cluster, you can go ahead and start it.
+
+NOTE: When you'd start the cluster, you would be asked for pull secret. You need to create a Red Hat account and download
+this file from the Pull Secret section of the link:https://console.redhat.com/openshift/create/local[{prod} page on the {rh} Hybrid Cloud Console].
+
+[subs="+quotes,attributes"]
+----
+$ {bin} start
+----
+
+**Log into your cluster**
+
+Once you've created the cluster, and it's up and running, you need to log in into your {openshift} cluster. In order to do that, use {openshift} CLI ([command]`oc`).
+
+If you already have {openshift} CLI ([command]`oc`), you can start using it. If not, you can use Run the [command]`{bin} oc-env`
+command to print the command needed to add the cached [command]`oc` executable to your `$PATH`.
+
+[subs="+quotes,attributes"]
+----
+$ {bin} oc-env
+----
+
+Get the {openshift} CLI ([command]`oc`) login command using [command]`{bin} console` to login as regular user or admin.
+
+Copy login command from this {prod} command output and paste it into your terminal:
+[subs="+quotes,attributes"]
+----
+$ {bin} console --credentials
+----
+
+**Deploy a sample application to your {openshift} cluster**
+
+We will be deploying a simple Java application using a tool called https://eclipse.dev/jkube/docs/openshift-maven-plugin/[Eclipse JKube OpenShift Maven Plugin].
+
+In order to follow these steps, you would need to have these installed:
+
+- https://adoptium.net/temurin/releases/[Java Development Kit]
+- https://maven.apache.org/[Apache Maven]
+
+Once you've installed these dependencies, you can deploy any java application to {openshift} cluster.
+
+Clone Eclipse JKube repository and go to one of the quickstarts:
+
+[subs="+quotes,attributes"]
+----
+$ git clone https://github.com/eclipse-jkube/jkube.git
+$ cd jkube/quickstarts/maven/quarkus
+----
+
+Run JKube OpenShift Maven Plugin goal to build and deploy application to {openshift} cluster:
+
+[subs="+quotes,attributes"]
+----
+$ mvn package oc:build oc:resource oc:apply
+----
+
+Wait till application pod comes in ready state and access the application via route:
+
+[subs="+quotes,attributes"]
+----
+$ oc get routes
+$ curl http://quarkus-default.apps-crc.testing
+----

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -1,0 +1,26 @@
+:description: Getting Started
+= Get started!
+
+{prod} is local {openshift}, focusing on making it easy to learn and develop for {openshift}. This guide will help you
+get started with CodeReady Containers ({prod}) in OpenShift. {prod} provides a way to run OpenShift locally for development
+and testing purposes.
+
+== Getting {prod}
+In order to download and install {prod}, please refer to the xref:installing.adoc[Installation Guide].
+
+- Ensure you have the minimum hardware and software requirements for {prod}.
+- Download the latest {prod} release from the official website.
+- Install the {prod} binary and add it to your system's PATH.
+
+[id='creating-openshift-preset']
+== Creating {openshift} cluster
+include::getting-started-scenarios/openshift.adoc[]
+
+[id='creating-okd-preset']
+== Creating {okd} cluster
+include::getting-started-scenarios/okd.adoc[]
+
+
+[id='creating-microshift-preset']
+== Creating {ushift} cluster
+include::getting-started-scenarios/microshift.adoc[]


### PR DESCRIPTION
# Description

Related to #16

Add a documentation section for getting started scenarios for OpenShift, OKD and MicroShift presets. These scenarios include these steps:
- How to configure cluster with a particular preset
- How to setup cluster
- How to start cluster
- Login into the cluster
- Deploy a sample application to Cluster