### PR TITLE
doc : Add note to `crc console` section about supported presets

### DIFF
--- a/modules/ROOT/pages/using.adoc
+++ b/modules/ROOT/pages/using.adoc
@@ -174,6 +174,8 @@ Access the {ocp} cluster running in the {prod} instance by using the {ocp} web c
 [id='accessing-the-openshift-web-console']
 === Accessing the {openshift} web console
 
+NOTE: This feature is only available for clusters configured with {openshift} or {okd} presets.
+
 Access the {ocp} web console by using your web browser.
 
 Access the cluster by using either the `kubeadmin` or `developer` user.
@@ -181,7 +183,7 @@ Use the `developer` user for creating projects or {openshift} applications and f
 Use the `kubeadmin` user only for administrative tasks such as creating new users or setting roles.
 
 .Prerequisites
-* {prod} is configured to use the {openshift} preset.
+* {prod} is configured to use the {openshift} or {okd} preset.
 See: xref:configuring.adoc#changing-the-selected-preset[Changing the selected preset].
 * A running {prod} instance.
 See: xref:starting-the-instance[Starting the instance].
@@ -210,10 +212,12 @@ See xref:troubleshooting.adoc[Troubleshooting {prod}] if you cannot access the {
 [id='accessing-the-openshift-cluster-with-the-openshift-cli']
 === Accessing the {openshift} cluster with the {openshift} CLI
 
+NOTE: This feature is only available for clusters configured with {openshift} or {okd} presets.
+
 Access the {ocp} cluster managed by {prod} by using the {openshift} CLI ([command]`oc`).
 
 .Prerequisites
-* {prod} is configured to use the {openshift} preset.
+* {prod} is configured to use the {openshift} or {okd} preset.
 See: xref:configuring.adoc#changing-the-selected-preset[Changing the selected preset].
 * A running {prod} instance.
 See: xref:starting-the-instance[Starting the instance].


### PR DESCRIPTION
## Description

Related to https://github.com/crc-org/crc/issues/4561

Add note clarifying `crc console` only works when it is configured with OpenShift or OKD preset