### PR TITLE
added note about disabling systemd-resolved

### DIFF
--- a/modules/ROOT/pages/networking.adoc
+++ b/modules/ROOT/pages/networking.adoc
@@ -311,3 +311,16 @@ $ oc login -u developer -p developer https://api.crc.testing:6443
 ----
 +
 The remote {ocp} web console is available at \https://console-openshift-console.apps-crc.testing.
+
++
+[NOTE]
+====
+Systems that utilise `systemd-resolved` might need to stop and disable the resloved service. For example:
+
+```
+$ sudo systemctl stop systemd-resolved
+$ sudo systemctl disable systemd-resolved
+```
+
+followed by a reboot, might be required.
+====


### PR DESCRIPTION
Added a note in the "Connecting to a remote instance" section highlighting the fact that on systems utilising systemd-resolved the service might need to be stopped and disabled 