### PR TITLE
Correct command typo in documentation

### DIFF
--- a/modules/ROOT/pages/using.adoc
+++ b/modules/ROOT/pages/using.adoc
@@ -364,7 +364,7 @@ $ odo login -u developer -p developer
 +
 [subs="+quotes,attributes"]
 ----
-$ odo project create sample-app
+$ odo create project sample-app
 ----
 
 . Create a directory for your components:


### PR DESCRIPTION
Quick typo fix in ["Using CRC"](https://crc.dev/docs/using/#deploying-a-sample-application-with-odo) documentation page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the command example for creating a project with `odo` to use the latest syntax in the user guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->